### PR TITLE
feat: SAGA

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
     "start": "cds-serve"
   },
   "dependencies": {
-    "@cap-js/hana": ">=2.1.2",
     "@sap/cds": ">=9"
   },
   "devDependencies": {
     "@cap-js/sqlite": ">=2"
+  },
+  "cds": {
+    "requires": {
+      "messaging": "file-based-messaging"
+    }
   },
   "license": "Apache-2.0"
 }

--- a/srv/data-service.js
+++ b/srv/data-service.js
@@ -1,18 +1,28 @@
 const cds = require ('@sap/cds')
-class DataService extends cds.ApplicationService { init() {
+class DataService extends cds.ApplicationService { async init() {
+
+  const messaging = await cds.connect.to ('messaging')
 
   const { Flights } = cds.entities ('sap.capire.flights')
 
   this.on ('BookingCreated', async req => {
     const { flight, date, seats = [null] } = req.data
-    await UPDATE (Flights, { flight_ID:flight, date }) 
-    .set `occupied_seats = occupied_seats + ${seats.length}`
+    const confirmed = await UPDATE (Flights, { flight_ID:flight, date })
+      .set `occupied_seats = occupied_seats + ${seats.length}`
+      .where `free_seats >= ${seats.length}`
+    if (!confirmed) req.reject('Flight is fully booked')
+
+    // messages can overtake each other -> don't propagate free seats in payload
+    messaging.emit('FlightUpdated', { flight_ID:flight, date })
   })
 
   this.on ('BookingDeleted', async (req) => {
     const { flight, date, seats = [null] } = req.data
-    await UPDATE (Flights, { flight_ID:flight, date }) 
-    .set `occupied_seats = occupied_seats - ${seats.length}`
+    await UPDATE (Flights, { flight_ID:flight, date })
+      .set `occupied_seats = occupied_seats - ${seats.length}`
+
+    // messages can overtake each other -> don't propagate free seats in payload
+    messaging.emit('FlightUpdated', { flight_ID:flight, date })
   })
 
   return super.init()


### PR DESCRIPTION
xtravels sibling: https://github.com/capire/xtravels/pull/46

---

- `BookingCreated` handler checks remaining capacity
- `BookingCreated` and `BookingDeleted` handlers emit a `FlightUpdated` event such that xtravels can fetch the new free seat count for its replicated flights