### PR TITLE
Remove annotation @data.product

### DIFF
--- a/srv/data-service.cds
+++ b/srv/data-service.cds
@@ -3,9 +3,8 @@ using sap.capire.flights as x from '../db/schema';
 /**
  * Master data service providing flight-related data, e.g. Flights, Airlines,
  * Airports, and Supplements (e.g. extra luggage, meals, etc.).
- * Served as SAP data product, and protocols supported by CAP.
  */
-@data.product @hcql @rest @odata @graphql
+@hcql @rest @odata @graphql
 service sap.capire.flights.data {
 
   // Serve Flights data via denormalized view with flattened FlightConnections


### PR DESCRIPTION
This annotation triggers special builds for BDC data products (or is used for data fed via synonyms) and should not be present at entities forming the API for service level data federatin